### PR TITLE
Prevent tsc from processing types from other node modules

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "outDir": "./built",
     "target": "es5",
+    "types" : ["mocha", "node"],
     "strict": true,
     "declaration": true,
     "removeComments": true,


### PR DESCRIPTION
The TSC docs state:
`By default all visible “@types” packages are included in your compilation. Packages in node_modules/@types of any enclosing folder are considered visible`

This means any types that adhere to different target/lib settings can get pulled in by tsc when installing this package. Specifying the explicit "types" list disables this behavior.